### PR TITLE
fix: javascript console.log 버그

### DIFF
--- a/services/run-code.ts
+++ b/services/run-code.ts
@@ -77,12 +77,16 @@ export const runCode = async ({ language, code, testCases }: RunCodeBody) => {
         "fs.readFileSync('/dev/stdin').toString().trim()",
         `\`${testCase.input}\``
       );
+
+      newCode = `console={};console.log = (...values) => {
+        output += values.join(' ');
+        output += '\\n';
+      };\n${newCode}`;
       newCode = `let output = '';\n${newCode}`;
-      newCode = newCode.replace(/console\.log\((.*?)\)/g, 'output += $1');
       newCode = `${newCode}\noutput;`;
 
       try {
-        const output = String(eval(newCode));
+        const output = String(eval(newCode)).trimEnd();
 
         results.push({
           caseNumber: i + 1,


### PR DESCRIPTION
console.log를 오버라이드하는 방식으로 기존 방식인 정규표현식으로 인해 생길 수 있는 버그를 해결합니다.
Closes #1 #3 